### PR TITLE
Add --check flag to test images

### DIFF
--- a/registry_scraper/__main__.py
+++ b/registry_scraper/__main__.py
@@ -22,6 +22,11 @@ def main():
                         help="Registry data directory or S3 bucket")
     parser.add_argument('-o', '--output-dir', type=str, default='data-copy',
                         help="Path to copy to")
+    parser.add_argument('-c', '--check', dest='check', action='store_true',
+                        help="Only check files, don't download them")
+    parser.add_argument('--no-check', dest='check', action='store_false',
+                        help="Download files, don't just check them")
+    parser.set_defaults(check=False)
 
     args = parser.parse_args()
 
@@ -31,7 +36,11 @@ def main():
         image, tag = _split_image_and_tag(img)
         paths.update(scraper.get_paths(image, tag))
     pprint(paths)
-    scraper.copy_paths(paths, args.output_dir)
+    if args.check:
+        scraper.check_paths(paths)
+        print("Image(s) {} successfully checked".format(args.image))
+    else:
+        scraper.copy_paths(paths, args.output_dir)
 
 
 if __name__ == '__main__':

--- a/registry_scraper/storage_drivers/s3.py
+++ b/registry_scraper/storage_drivers/s3.py
@@ -42,7 +42,8 @@ class S3Storage(object):
         for item in self.bucket.list(path):
             if item is not None:
                 return True
-        return False
+        raise PathNotFound("The specified path was not found: {}"
+                           .format(path))
 
     def _copy_file(self, path, new_path):
         if not os.path.exists(new_path):

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -78,10 +78,15 @@ test-local-storage-image: run-local-storage-test-registry
 test-s3-storage-image: run-s3-storage-test-registry
 	docker run --rm localhost:5003/$(IMAGE_NAME) echo "I'm working!"
 
+test-check-local: install-scrape push-image-local-storage
+	scrape --check $(IMAGE_NAME)
+
+test-check-s3: install-scrape push-image-s3-storage
+	scrape -s s3 -d $(S3_BUCKET) --check $(IMAGE_NAME)
 
 test-local: clean test-local-storage-image
 
-test-s3: clean test-s3-storage-image
+test-s3: clean test-s3-storage-image test-check-s3
 
 test: test-local test-s3 
 


### PR DESCRIPTION
This is a feature that we want to use in a script that checks our
docker registry as a monitor to ensure that no files are missing from
the registry. This lets you ensure that they are all there without
downloading them.
